### PR TITLE
Add OAuth2 authentication support with Google and GitHub, including user model updates and new DTOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ target/
 .springBeans
 .sts4-cache
 
+.env
+.env.local
+.env.production
+.env.test
+
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ docker-compose logs -f
 
 – `/api/v1/auth/signin` – Авторизация пользователя
 
+– GET `/login` - Страница авторизации
+
+– POST `/login` - Авторизация пользователя с передачей логина и пароля
+
+– `/oauth2/redirect` - Страница с токеном при успешной авторизации через Oauth
+
 ## Configuration:
 
 `server.port` – Порт, на котором будет запущено приложение (по умолчанию 8081)
@@ -79,3 +85,11 @@ docker-compose logs -f
 `application.security.jwt.secret-key` – Секретный ключ для JWT
 
 `application.security.jwt.expiration` – Время жизни JWT (в секундах)
+
+`spring.security.oauth2.client.registration.github.client-id` - ID приложения для авторизации через GitHub
+
+`spring.security.oauth2.client.registration.github.client-secret` - Секретный ключ приложения для авторизации через GitHub
+
+`spring.security.oauth2.client.registration.google.client-id` - ID приложения для авторизации через Google
+
+`spring.security.oauth2.client.registration.google.client-secret` - Секретный ключ приложения для авторизации через Google

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
@@ -96,6 +100,14 @@
             <artifactId>jjwt-impl</artifactId>
             <version>${jsonwebtoken.version}</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/io/github/authmicroservice/controller/OauthController.java
+++ b/src/main/java/io/github/authmicroservice/controller/OauthController.java
@@ -1,0 +1,59 @@
+package io.github.authmicroservice.controller;
+
+import io.github.authmicroservice.model.dto.JwtResponse;
+import io.github.authmicroservice.model.dto.SigninRequest;
+import io.github.authmicroservice.service.AuthService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class OauthController {
+
+    private final AuthService authService;
+
+    public OauthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/")
+    public String home() {
+        return "redirect:/login";
+    }
+
+    @GetMapping("/login")
+    public String loginPage(@RequestParam(value = "error", required = false) String error,
+                            @RequestParam(value = "message", required = false) String message,
+                            Model model) {
+        if (error != null) {
+            model.addAttribute("error", true);
+            model.addAttribute("errorMessage", message != null ? message : "Authentication failed");
+        }
+        model.addAttribute("signinRequest", new SigninRequest());
+        return "login";
+    }
+
+    @PostMapping("/login")
+    public String login(@ModelAttribute SigninRequest signinRequest, Model model) {
+        try {
+            JwtResponse jwtResponse = authService.signin(signinRequest);
+            return "redirect:/oauth2/redirect?token=" + jwtResponse.getToken();
+        } catch (Exception e) {
+            model.addAttribute("error", true);
+            model.addAttribute("errorMessage", "Invalid credentials");
+            model.addAttribute("signinRequest", signinRequest);
+            return "login";
+        }
+    }
+
+    @GetMapping("/oauth2/redirect")
+    public String oauth2Redirect(@RequestParam("token") String token, Model model) {
+        model.addAttribute("accessToken", token);
+        return "oauth2-redirect";
+    }
+
+}
+

--- a/src/main/java/io/github/authmicroservice/model/dto/GitHubLoginInfo.java
+++ b/src/main/java/io/github/authmicroservice/model/dto/GitHubLoginInfo.java
@@ -1,0 +1,23 @@
+package io.github.authmicroservice.model.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * DTO для хранения информации о пользователе GitHub при OAuth авторизации
+ */
+@Data
+@Builder
+public class GitHubLoginInfo {
+
+    private String id;
+
+    private String login;
+
+    private String name;
+
+    private String email;
+
+    private String avatarUrl;
+
+}

--- a/src/main/java/io/github/authmicroservice/model/dto/GoogleLoginInfo.java
+++ b/src/main/java/io/github/authmicroservice/model/dto/GoogleLoginInfo.java
@@ -1,0 +1,25 @@
+package io.github.authmicroservice.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO для хранения информации о пользователе Google при OAuth авторизации
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleLoginInfo {
+
+    private String id;
+
+    private String email;
+
+    private String name;
+
+    private String picture;
+
+}

--- a/src/main/java/io/github/authmicroservice/model/entity/Role.java
+++ b/src/main/java/io/github/authmicroservice/model/entity/Role.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Role {
 
     @Id

--- a/src/main/java/io/github/authmicroservice/model/entity/User.java
+++ b/src/main/java/io/github/authmicroservice/model/entity/User.java
@@ -1,6 +1,9 @@
 package io.github.authmicroservice.model.entity;
 
+import io.github.authmicroservice.model.enums.Provider;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Column;
@@ -31,14 +34,30 @@ public class User implements UserDetails {
     @Id
     private String login;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(name = "provider_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
     @Column(nullable = false)
     private boolean active;
+
+    @Column(name = "google_id")
+    private String googleId;
+
+    @Column(name = "github_id")
+    private String githubId;
+
+    @Column(name = "full_name")
+    private String fullName;
+
+    @Column(name = "profile_picture_url")
+    private String profilePictureUrl;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserRole> roles;

--- a/src/main/java/io/github/authmicroservice/model/enums/Provider.java
+++ b/src/main/java/io/github/authmicroservice/model/enums/Provider.java
@@ -1,0 +1,10 @@
+package io.github.authmicroservice.model.enums;
+
+public enum Provider {
+
+    LOCAL,
+    GOOGLE,
+    GITHUB
+
+}
+

--- a/src/main/java/io/github/authmicroservice/repository/UserRepository.java
+++ b/src/main/java/io/github/authmicroservice/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package io.github.authmicroservice.repository;
 
 import io.github.authmicroservice.model.entity.User;
+import io.github.authmicroservice.model.enums.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -13,9 +14,27 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, String> {
 
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndProvider(String email, Provider provider);
 
     Optional<User> findByLogin(String login);
+
+    @Query("""
+    SELECT u FROM User u
+    LEFT JOIN FETCH u.roles ur
+    LEFT JOIN FETCH ur.role
+    WHERE u.email = :email
+    AND u.provider = 'GOOGLE'
+    """)
+    Optional<User> findByEmailWithRoles(String email);
+
+    @Query("""
+    SELECT u FROM User u
+    LEFT JOIN FETCH u.roles ur
+    LEFT JOIN FETCH ur.role
+    WHERE u.githubId = :githubId
+    AND u.provider = 'GITHUB'
+    """)
+    Optional<User> findByGitHubIdWithRoles(String githubId);
 
     @Query("""
     SELECT u FROM User u

--- a/src/main/java/io/github/authmicroservice/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/io/github/authmicroservice/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,34 @@
+package io.github.authmicroservice.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+/**
+ * Обработчик неудачной аутентификации OAuth2;
+ * Перенаправляет пользователя на страницу с сообщением ошибки.
+ */
+@Component
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+
+        String errorUrl = UriComponentsBuilder
+                .fromUriString("/login")
+                .queryParam("error", "oauth_failed")
+                .queryParam("message", exception.getMessage())
+                .build().toUriString();
+
+        response.sendRedirect(errorUrl);
+    }
+
+}
+

--- a/src/main/java/io/github/authmicroservice/security/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/authmicroservice/security/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,117 @@
+package io.github.authmicroservice.security.handler;
+
+import io.github.authmicroservice.model.dto.GitHubLoginInfo;
+import io.github.authmicroservice.model.dto.GoogleLoginInfo;
+import io.github.authmicroservice.model.dto.JwtResponse;
+import io.github.authmicroservice.service.AuthService;
+import io.github.authmicroservice.service.GitHubApiService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * Обработчик успешной аутентификации OAuth2;
+ * Перенаправляет пользователя на страницу с JWT токеном.
+ */
+@Component
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final AuthService authService;
+    private final GitHubApiService gitHubApiService;
+
+    public OAuth2AuthenticationSuccessHandler(@Lazy AuthService authService, GitHubApiService gitHubApiService) {
+        this.authService = authService;
+        this.gitHubApiService = gitHubApiService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        try {
+            OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+            OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+            String registrationId = ((OAuth2AuthenticationToken) authentication)
+                    .getAuthorizedClientRegistrationId();
+
+            JwtResponse jwtResponse;
+
+
+            if ("google".equals(registrationId)) {
+
+                GoogleLoginInfo googleUserInfo = GoogleLoginInfo.builder()
+                        .id(oauth2User.getAttribute("sub"))
+                        .email(oauth2User.getAttribute("email"))
+                        .name(oauth2User.getAttribute("name"))
+                        .picture(oauth2User.getAttribute("picture"))
+                        .build();
+
+                jwtResponse = authService.googleOauthLoginProcess(googleUserInfo);
+
+            } else if ("github".equals(registrationId)) {
+
+                Integer id = oauth2User.getAttribute("id");
+
+                String email = oauth2User.getAttribute("email");
+
+                if (email == null) {
+                    Optional<String> apiEmail = gitHubApiService.getPrimaryEmail(token);
+                    if (apiEmail.isPresent()) {
+                        email = apiEmail.get();
+                    }
+                }
+
+                GitHubLoginInfo gitHubUserInfo = GitHubLoginInfo.builder()
+                        .id(String.valueOf(id))
+                        .login(oauth2User.getAttribute("login"))
+                        .name(oauth2User.getAttribute("name"))
+                        .email(email)
+                        .avatarUrl(oauth2User.getAttribute("avatar_url"))
+                        .build();
+
+                jwtResponse = authService.githubOauthLoginProcess(gitHubUserInfo);
+
+            } else {
+
+                throw new IllegalArgumentException("Unsupported OAuth2 provider: " + registrationId);
+
+            }
+
+            String responseToken = jwtResponse.getToken();
+
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString("/oauth2/redirect")
+                    .queryParam("token", responseToken)
+                    .build(true)
+                    .toUriString();
+
+            response.sendRedirect(redirectUrl);
+
+        } catch (Exception e) {
+
+            String error = URLEncoder.encode(e.getMessage()
+                    .replaceAll("[\r\n]", " "), StandardCharsets.UTF_8);
+
+            String errorUrl = UriComponentsBuilder
+                    .fromUriString("/login")
+                    .queryParam("error", "oauth_failed")
+                    .queryParam("message", error)
+                    .build(true)
+                    .toUriString();
+
+            response.sendRedirect(errorUrl);
+        }
+    }
+
+}

--- a/src/main/java/io/github/authmicroservice/service/AuthService.java
+++ b/src/main/java/io/github/authmicroservice/service/AuthService.java
@@ -1,13 +1,32 @@
 package io.github.authmicroservice.service;
 
+import io.github.authmicroservice.model.dto.GitHubLoginInfo;
+import io.github.authmicroservice.model.dto.GoogleLoginInfo;
 import io.github.authmicroservice.model.dto.JwtResponse;
 import io.github.authmicroservice.model.dto.SigninRequest;
 import io.github.authmicroservice.model.dto.SignupRequest;
 
 public interface AuthService {
 
+    /**
+     * Регистрация нового пользователя
+     */
     void signup(SignupRequest request);
 
+    /**
+     * Авторизация пользователя
+     * @return JWT токен
+     */
     JwtResponse signin(SigninRequest request);
+
+    /**
+     * Процесс OAuth авторизации через Google
+     */
+    JwtResponse googleOauthLoginProcess(GoogleLoginInfo googleUserInfo);
+
+    /**
+     * Процесс OAuth авторизации через GitHub
+     */
+    JwtResponse githubOauthLoginProcess(GitHubLoginInfo gitHubUserInfo);
 
 }

--- a/src/main/java/io/github/authmicroservice/service/AuthServiceImpl.java
+++ b/src/main/java/io/github/authmicroservice/service/AuthServiceImpl.java
@@ -1,11 +1,14 @@
 package io.github.authmicroservice.service;
 
+import io.github.authmicroservice.model.dto.GitHubLoginInfo;
+import io.github.authmicroservice.model.dto.GoogleLoginInfo;
 import io.github.authmicroservice.model.dto.JwtResponse;
 import io.github.authmicroservice.model.dto.SigninRequest;
 import io.github.authmicroservice.model.dto.SignupRequest;
 import io.github.authmicroservice.model.entity.Role;
 import io.github.authmicroservice.model.entity.User;
 import io.github.authmicroservice.model.entity.UserRole;
+import io.github.authmicroservice.model.enums.Provider;
 import io.github.authmicroservice.repository.RoleRepository;
 import io.github.authmicroservice.repository.UserRepository;
 import io.github.authmicroservice.repository.UserRoleRepository;
@@ -22,7 +25,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -57,24 +62,25 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public void signup(SignupRequest request) {
 
-        log.info("Attempting to register user: {}", request.getLogin());
+        log.debug("Attempting to register user: {}", request.getLogin());
 
         if (userRepository.existsById(request.getLogin())) {
             throw new EntityExistsException("User with login " + request.getLogin() + " already exists");
         }
 
-        if (userRepository.existsByEmail(request.getEmail())) {
+        if (userRepository.existsByEmailAndProvider(request.getEmail(), Provider.LOCAL)) {
             throw new EntityExistsException("User with email " + request.getEmail() + " already exists");
         }
 
         User user = User.builder()
                 .login(request.getLogin())
                 .email(request.getEmail())
+                .provider(Provider.LOCAL)
                 .password(passwordEncoder.encode(request.getPassword(), request.getLogin(), request.getEmail()))
                 .active(true)
                 .build();
 
-        log.info("Save user: {}", user.getLogin());
+        log.debug("Save user: {}", user.getLogin());
 
         userRepository.save(user);
 
@@ -92,7 +98,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public JwtResponse signin(SigninRequest request) {
 
-        log.info("Attempting to authenticate user: {}", request.getLogin());
+        log.debug("Attempting to authenticate user: {}", request.getLogin());
 
         try {
             Authentication authentication = authenticationManager.authenticate(
@@ -109,7 +115,7 @@ public class AuthServiceImpl implements AuthService {
                     .map(GrantedAuthority::getAuthority)
                     .collect(Collectors.toList());
 
-            log.info("User {} authenticated successfully", userDetails.getUsername());
+            log.debug("User {} authenticated successfully", userDetails.getUsername());
 
             return JwtResponse.builder()
                     .token(jwt)
@@ -120,6 +126,148 @@ public class AuthServiceImpl implements AuthService {
             log.error("Authentication failed for user {}: {}", request.getLogin(), e.getMessage());
             throw e;
         }
+    }
+
+    @Override
+    public JwtResponse googleOauthLoginProcess(GoogleLoginInfo googleUserInfo) {
+
+        Optional<User> existingUser = userRepository.findByEmailWithRoles(googleUserInfo.getEmail());
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            if (user.getProvider() == Provider.LOCAL) {
+                throw new IllegalStateException("User with email " + googleUserInfo.getEmail() +
+                        " was registered locally. Cannot authenticate via Google OAuth2.");
+            }
+
+            user.setFullName(googleUserInfo.getName());
+            user.setProfilePictureUrl(googleUserInfo.getPicture());
+            user.setGoogleId(googleUserInfo.getId());
+            userRepository.save(user);
+
+            String jwt = jwtService.generateToken(user);
+
+            List<String> roles = user.getRoles().stream()
+                    .map(UserRole::getRole)
+                    .map(role -> "ROLE_" + role.getId().name())
+                    .toList();
+
+            return JwtResponse.builder()
+                    .token(jwt)
+                    .login(user.getLogin())
+                    .roles(roles)
+                    .build();
+        } else {
+
+            Role userRole = roleRepository.findById(Role.RoleType.USER)
+                    .orElseThrow(() -> new IllegalStateException("USER role not found"));
+
+            String login = googleUserInfo.getEmail().split("@")[0];
+
+            User user = User.builder()
+                    .login(login)
+                    .email(googleUserInfo.getEmail())
+                    .password(null)
+                    .active(true)
+                    .provider(Provider.GOOGLE)
+                    .googleId(googleUserInfo.getId())
+                    .fullName(googleUserInfo.getName())
+                    .profilePictureUrl(googleUserInfo.getPicture())
+                    .build();
+
+            user = userRepository.save(user);
+
+            UserRole userRoleEntity = UserRole.builder()
+                    .user(user)
+                    .role(userRole)
+                    .build();
+
+            user.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+            user = userRepository.save(user);
+
+            String jwt = jwtService.generateToken(user);
+
+            return JwtResponse.builder()
+                    .token(jwt)
+                    .login(user.getLogin())
+                    .roles(List.of("ROLE_USER"))
+                    .build();
+
+        }
+    }
+
+    @Override
+    public JwtResponse githubOauthLoginProcess(GitHubLoginInfo gitHubUserInfo) {
+
+        log.debug("Processing GitHub OAuth login for user: {}", gitHubUserInfo.getLogin());
+
+        Optional<User> existingUser = userRepository.findByGitHubIdWithRoles(gitHubUserInfo.getId());
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            if (user.getProvider() == Provider.LOCAL) {
+                throw new IllegalStateException("User with GitHub ID " + gitHubUserInfo.getId() +
+                        " was registered locally. Cannot authenticate via GitHub OAuth2.");
+            }
+
+            user.setFullName(gitHubUserInfo.getName());
+            user.setProfilePictureUrl(gitHubUserInfo.getAvatarUrl());
+            user.setGithubId(gitHubUserInfo.getId());
+            userRepository.save(user);
+
+            String jwt = jwtService.generateToken(user);
+
+            List<String> roles = user.getRoles().stream()
+                    .map(UserRole::getRole)
+                    .map(role -> "ROLE_" + role.getId().name())
+                    .toList();
+
+            log.debug("Existing GitHub user {} updated and authenticated successfully", user.getLogin());
+
+            return JwtResponse.builder()
+                    .token(jwt)
+                    .login(user.getLogin())
+                    .roles(roles)
+                    .build();
+        } else {
+
+            Role userRole = roleRepository.findById(Role.RoleType.USER)
+                    .orElseThrow(() -> new IllegalStateException("USER role not found"));
+
+            User user = User.builder()
+                    .login(gitHubUserInfo.getLogin())
+                    .email(gitHubUserInfo.getEmail())
+                    .githubId(gitHubUserInfo.getId())
+                    .password(null)
+                    .active(true)
+                    .provider(Provider.GITHUB)
+                    .fullName(gitHubUserInfo.getName())
+                    .profilePictureUrl(gitHubUserInfo.getAvatarUrl())
+                    .build();
+
+            user = userRepository.save(user);
+
+            UserRole userRoleEntity = UserRole.builder()
+                    .user(user)
+                    .role(userRole)
+                    .build();
+
+            user.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+            user = userRepository.save(user);
+
+            String jwt = jwtService.generateToken(user);
+
+            log.debug("New GitHub user {} created and authenticated successfully", user.getLogin());
+
+            return JwtResponse.builder()
+                    .token(jwt)
+                    .login(user.getLogin())
+                    .roles(List.of("ROLE_USER"))
+                    .build();
+        }
+
     }
 
 }

--- a/src/main/java/io/github/authmicroservice/service/GitHubApiService.java
+++ b/src/main/java/io/github/authmicroservice/service/GitHubApiService.java
@@ -1,0 +1,101 @@
+package io.github.authmicroservice.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Сервис для работы с GitHub API (так как git не всегда возвращает email при oauth запросе)
+ * В этом сервисе используется для получения почты пользователя GitHub
+ */
+@Service
+@Slf4j
+public class GitHubApiService {
+
+    @Data
+    public static class GitHubEmail {
+
+        private String email;
+
+        private boolean primary;
+
+        private boolean verified;
+
+        @JsonProperty("visibility")
+        private String visibility;
+
+    }
+
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final RestTemplate restTemplate;
+
+    public GitHubApiService(OAuth2AuthorizedClientService authorizedClientService) {
+        this.authorizedClientService = authorizedClientService;
+        this.restTemplate = new RestTemplate();
+    }
+
+    /**
+     * Получает primary email пользователя GitHub через API
+     */
+    public Optional<String> getPrimaryEmail(OAuth2AuthenticationToken token) {
+        try {
+            OAuth2AuthorizedClient client = authorizedClientService
+                    .loadAuthorizedClient("github", token.getName());
+
+            if (client == null) {
+                log.warn("No authorized client found for GitHub");
+                return Optional.empty();
+            }
+
+            String accessToken = client.getAccessToken().getTokenValue();
+            return fetchPrimaryEmailFromApi(accessToken);
+
+        } catch (Exception e) {
+            log.error("Error fetching GitHub email: {}", e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> fetchPrimaryEmailFromApi(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.set("Accept", "application/vnd.github.v3+json");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<GitHubEmail[]> response = restTemplate.exchange(
+                    "https://api.github.com/user/emails",
+                    HttpMethod.GET,
+                    entity,
+                    GitHubEmail[].class
+            );
+
+            GitHubEmail[] emails = response.getBody();
+            if (emails != null) {
+                return Arrays.stream(emails)
+                        .filter(email -> email.isPrimary() && email.isVerified())
+                        .findFirst()
+                        .map(GitHubEmail::getEmail);
+            }
+
+        } catch (Exception e) {
+            log.error("Failed to fetch emails from GitHub API: {}", e.getMessage());
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/io/github/authmicroservice/service/OauthUserService.java
+++ b/src/main/java/io/github/authmicroservice/service/OauthUserService.java
@@ -1,0 +1,140 @@
+package io.github.authmicroservice.service;
+
+import io.github.authmicroservice.model.dto.GitHubLoginInfo;
+import io.github.authmicroservice.model.dto.GoogleLoginInfo;
+import io.github.authmicroservice.model.entity.Role;
+import io.github.authmicroservice.model.entity.User;
+import io.github.authmicroservice.model.entity.UserRole;
+import io.github.authmicroservice.model.enums.Provider;
+import io.github.authmicroservice.repository.RoleRepository;
+import io.github.authmicroservice.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Сервис для работы с oauth пользователями
+ */
+@Service
+public class OauthUserService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+
+    public OauthUserService(UserRepository userRepository,
+                       RoleRepository roleRepository) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    @Transactional
+    public User processGoogleOAuthUser(GoogleLoginInfo googleUserInfo) {
+
+        Optional<User> existingUser = userRepository.findByEmailWithRoles(googleUserInfo.getEmail());
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            if (user.getProvider() == Provider.LOCAL) {
+                throw new IllegalStateException("User with email " + googleUserInfo.getEmail() +
+                        " was registered locally. Cannot authenticate via Google OAuth2.");
+            }
+
+            user.setFullName(googleUserInfo.getName());
+            user.setProfilePictureUrl(googleUserInfo.getPicture());
+            user.setGoogleId(googleUserInfo.getId());
+            return userRepository.save(user);
+
+        } else {
+
+            Role userRole = checkUserRoleExists();
+
+            String login = googleUserInfo.getEmail().split("@")[0];
+
+            User user = User.builder()
+                    .login(login)
+                    .email(googleUserInfo.getEmail())
+                    .password(null)
+                    .active(true)
+                    .provider(Provider.GOOGLE)
+                    .googleId(googleUserInfo.getId())
+                    .fullName(googleUserInfo.getName())
+                    .profilePictureUrl(googleUserInfo.getPicture())
+                    .build();
+
+            user = userRepository.save(user);
+
+            UserRole userRoleEntity = UserRole.builder()
+                    .user(user)
+                    .role(userRole)
+                    .build();
+
+            user.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+            return userRepository.save(user);
+
+        }
+    }
+
+    @Transactional
+    public User processGitHubOAuthUser(GitHubLoginInfo gitHubUserInfo) {
+
+        Optional<User> existingUser = userRepository.findByGitHubIdWithRoles(gitHubUserInfo.getId());
+
+        String newEmail = gitHubUserInfo.getEmail();
+
+        if (newEmail == null) {
+            newEmail = gitHubUserInfo.getLogin() + "_" + gitHubUserInfo.getId() + "@noreply.github.oauth";
+        }
+
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+
+            if (user.getProvider() == Provider.LOCAL) {
+                throw new IllegalStateException("User with GitHub ID " + gitHubUserInfo.getId() +
+                        " was registered locally. Cannot authenticate via GitHub OAuth2.");
+            }
+
+            user.setFullName(gitHubUserInfo.getName());
+            user.setProfilePictureUrl(gitHubUserInfo.getAvatarUrl());
+            user.setGithubId(gitHubUserInfo.getId());
+            return userRepository.save(user);
+
+        } else {
+
+            Role userRole = checkUserRoleExists();
+
+            User user = User.builder()
+                    .login(gitHubUserInfo.getLogin())
+                    .email(newEmail)
+                    .githubId(gitHubUserInfo.getId())
+                    .password(null)
+                    .active(true)
+                    .provider(Provider.GITHUB)
+                    .fullName(gitHubUserInfo.getName())
+                    .profilePictureUrl(gitHubUserInfo.getAvatarUrl())
+                    .build();
+
+            user = userRepository.save(user);
+
+            UserRole userRoleEntity = UserRole.builder()
+                    .user(user)
+                    .role(userRole)
+                    .build();
+
+            user.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+            return userRepository.save(user);
+
+        }
+    }
+
+    private Role checkUserRoleExists() {
+        Role userRole = roleRepository.findById(Role.RoleType.USER)
+                .orElseThrow(() -> new IllegalStateException("USER role not found"));
+
+        return userRole;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,14 @@
+spring.config.import=optional:file:.env[.properties]
+
 spring.application.name=AuthMicroservice
 
-server.port=8081
+server.port=8080
 
 spring.datasource.url=jdbc:postgresql://localhost:5433/auth_db
 spring.datasource.username=auth
 spring.datasource.password=12345
 spring.datasource.driver-class-name=org.postgresql.Driver
+
 
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,26 @@ auth.global.salt=randomSaltValue1234567890
 
 application.security.jwt.secret-key=mySecretKeyForJWTTokenGenerationAndValidation1234567890
 application.security.jwt.expiration=3600000
+
+# Google OAuth Configuration
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
+spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+
+spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth
+spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
+spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v3/userinfo
+spring.security.oauth2.client.provider.google.user-name-attribute=sub
+
+# GitHub OAuth Configuration
+spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+spring.security.oauth2.client.registration.github.scope=user:email,read:user
+spring.security.oauth2.client.registration.github.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.github.client-name=GitHub
+
+spring.security.oauth2.client.provider.github.authorization-uri=https://github.com/login/oauth/authorize
+spring.security.oauth2.client.provider.github.token-uri=https://github.com/login/oauth/access_token
+spring.security.oauth2.client.provider.github.user-info-uri=https://api.github.com/user
+spring.security.oauth2.client.provider.github.user-name-attribute=login

--- a/src/main/resources/db/changelog/releases/v0/0/1/001-create-users-table.yaml
+++ b/src/main/resources/db/changelog/releases/v0/0/1/001-create-users-table.yaml
@@ -21,7 +21,6 @@ databaseChangeLog:
                   name: email
                   type: VARCHAR(100)
                   constraints:
-                    unique: true
                     nullable: false
               - column:
                   name: active
@@ -29,6 +28,7 @@ databaseChangeLog:
                   defaultValueBoolean: true
                   constraints:
                     nullable: false
+
       rollback:
         - dropTable:
             tableName: users

--- a/src/main/resources/db/changelog/releases/v0/0/1/005-add-oauth-info-to-user.yaml
+++ b/src/main/resources/db/changelog/releases/v0/0/1/005-add-oauth-info-to-user.yaml
@@ -1,0 +1,63 @@
+databaseChangeLog:
+  - changeSet:
+      id: 005-add-oauth-info-to-user
+      author: developer
+      changes:
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: provider_type
+                  type: VARCHAR(20)
+                  defaultValue: LOCAL
+                  constraints:
+                    nullable: false
+
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: google_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: full_name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: profile_picture_url
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: true
+
+        - dropNotNullConstraint:
+            tableName: users
+            columnName: password
+            columnDataType: VARCHAR(255)
+
+        - addUniqueConstraint:
+            tableName: users
+            columnNames: google_id
+            constraintName: uk_users_google_id
+
+        - addUniqueConstraint:
+            tableName: users
+            columnNames: email, provider_type
+            constraintName: uk_users_provider_type_email
+
+        - createIndex:
+            tableName: users
+            indexName: idx_users_provider_type
+            columns:
+              - column:
+                  name: provider_type

--- a/src/main/resources/db/changelog/releases/v0/0/1/006-add-github-oauth-info-to-user.yaml
+++ b/src/main/resources/db/changelog/releases/v0/0/1/006-add-github-oauth-info-to-user.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 005-add-oauth-info-to-user
+      author: developer
+      changes:
+        - addColumn:
+            tableName: users
+            columns:
+              - column:
+                  name: github_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: true
+
+        - addUniqueConstraint:
+            tableName: users
+            columnNames: github_id
+            constraintName: uk_users_github_id

--- a/src/main/resources/db/changelog/releases/v0/0/1/006-add-github-oauth-info-to-user.yaml
+++ b/src/main/resources/db/changelog/releases/v0/0/1/006-add-github-oauth-info-to-user.yaml
@@ -16,3 +16,10 @@ databaseChangeLog:
             tableName: users
             columnNames: github_id
             constraintName: uk_users_github_id
+
+        - createIndex:
+            tableName: users
+            columns:
+              - column:
+                  name: email
+            indexName: idx_users_email

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f5f5f5;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+
+        .login-container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            width: 100%;
+            max-width: 400px;
+        }
+
+        h2 {
+            text-align: center;
+            margin-bottom: 30px;
+            color: #333;
+        }
+
+        .form-group {
+            margin-bottom: 20px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 5px;
+            color: #555;
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 12px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+
+        input:focus {
+            outline: none;
+            border-color: #007bff;
+        }
+
+        .btn {
+            width: 100%;
+            padding: 12px;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            cursor: pointer;
+            margin-bottom: 15px;
+        }
+
+        .btn-primary {
+            background-color: #007bff;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background-color: #0056b3;
+        }
+
+        .btn-google {
+            background-color: #db4437;
+            color: white;
+            text-decoration: none;
+            display: block;
+            text-align: center;
+        }
+
+        .btn-google:hover {
+            background-color: #c23321;
+        }
+
+        .btn-github {
+            background-color: #333;
+            color: white;
+            text-decoration: none;
+            display: block;
+            text-align: center;
+        }
+
+        .btn-github:hover {
+            background-color: #24292e;
+        }
+
+        .divider {
+            text-align: center;
+            margin: 20px 0;
+            color: #666;
+        }
+
+        .error {
+            background-color: #f8d7da;
+            color: #721c24;
+            padding: 10px;
+            border-radius: 4px;
+            margin-bottom: 20px;
+            border: 1px solid #f5c6cb;
+        }
+
+        .oauth-buttons {
+            margin-top: 20px;
+        }
+
+        .oauth-buttons .btn {
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+<div class="login-container">
+    <h2>Войти</h2>
+
+    <div th:if="${error}" class="error">
+        <span th:text="${errorMessage}">Error message</span>
+    </div>
+
+    <form th:action="@{/login}" th:object="${signinRequest}" method="post">
+        <div class="form-group">
+            <label for="login">Логин</label>
+            <input type="text" id="login" th:field="*{login}" required>
+        </div>
+
+        <div class="form-group">
+            <label for="password">Пароль</label>
+            <input type="password" id="password" th:field="*{password}" required>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Войти</button>
+    </form>
+
+    <div class="divider">или</div>
+
+    <div class="oauth-buttons">
+        <a href="/oauth2/authorization/google" class="btn btn-google">Войти через Google</a>
+
+        <a href="/oauth2/authorization/github" class="btn btn-github">Войти через GitHub</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/oauth2-redirect.html
+++ b/src/main/resources/templates/oauth2-redirect.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Авторизация успешна</title>
+  <style>
+    body {
+
+      font-family: Arial, sans-serif;
+      background-color: #f5f5f5;
+      margin: 0;
+      padding: 20px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    }
+
+    .success-container {
+      background: white;
+      padding: 30px;
+      border-radius: 8px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+      width: 100%;
+      max-width: 600px;
+      text-align: center;
+    }
+
+    h2 {
+      color: #28a745;
+      margin-bottom: 20px;
+    }
+
+    .token-container {
+      background-color: #f8f9fa;
+      padding: 20px;
+      border-radius: 4px;
+      margin: 20px 0;
+      border: 1px solid #dee2e6;
+    }
+
+    .token-label {
+      margin-bottom: 10px;
+      font-weight: bold;
+      color: #333;
+    }
+
+    .token-input {
+      width: 100%;
+      padding: 10px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-family: monospace;
+      font-size: 14px;
+      background-color: white;
+      box-sizing: border-box;
+      resize: none;
+      overflow-wrap: break-word;
+    }
+
+  </style>
+</head>
+<body>
+<div class="success-container">
+
+  <h2>Авторизация успешна!</h2>
+
+  <p>Вы успешно вошли в систему. Ваш токен доступа создан.</p>
+
+  <div class="token-container">
+    <div class="token-label">Токен доступа:</div>
+    <textarea class="token-input" id="accessToken" readonly rows="3" cols="30" th:text="${accessToken}"></textarea>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/src/test/java/io/github/authmicroservice/config/BaseTestSecurityConfig.java
+++ b/src/test/java/io/github/authmicroservice/config/BaseTestSecurityConfig.java
@@ -1,0 +1,45 @@
+package io.github.authmicroservice.config;
+
+import io.github.authmicroservice.security.auth.CustomAuthenticationProvider;
+import io.github.authmicroservice.security.handler.OAuth2AuthenticationFailureHandler;
+import io.github.authmicroservice.security.handler.OAuth2AuthenticationSuccessHandler;
+import io.github.authmicroservice.service.JwtService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@TestConfiguration
+public class BaseTestSecurityConfig {
+
+    @Bean
+    @Primary
+    public JwtService jwtService() {
+        return Mockito.mock(JwtService.class);
+    }
+
+    @Bean
+    @Primary
+    public UserDetailsService userDetailsService() {
+        return Mockito.mock(UserDetailsService.class);
+    }
+
+    @Bean
+    @Primary
+    public OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler() {
+        return Mockito.mock(OAuth2AuthenticationFailureHandler.class);
+    }
+
+    @Bean
+    @Primary
+    public OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler() {
+        return Mockito.mock(OAuth2AuthenticationSuccessHandler.class);
+    }
+
+    @Bean
+    @Primary
+    public CustomAuthenticationProvider customAuthenticationProvider() {
+        return Mockito.mock(CustomAuthenticationProvider.class);
+    }
+}

--- a/src/test/java/io/github/authmicroservice/controller/AuthControllerTest.java
+++ b/src/test/java/io/github/authmicroservice/controller/AuthControllerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -30,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @ExtendWith(MockitoExtension.class)
-public class AuthTest {
+public class AuthControllerTest {
 
     @Mock
     private AuthService authService;

--- a/src/test/java/io/github/authmicroservice/controller/OauthControllerTest.java
+++ b/src/test/java/io/github/authmicroservice/controller/OauthControllerTest.java
@@ -1,0 +1,103 @@
+package io.github.authmicroservice.controller;
+
+import io.github.authmicroservice.model.dto.JwtResponse;
+import io.github.authmicroservice.model.dto.SigninRequest;
+import io.github.authmicroservice.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OauthControllerTest {
+
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private OauthController oauthController;
+
+    private Model model;
+
+    @BeforeEach
+    void setUp() {
+        model = mock(Model.class);
+    }
+
+
+    @Test
+    void loginPage_Success() {
+        String result = oauthController.loginPage(null, null, model);
+
+        assertEquals("login", result);
+        verify(model, times(1)).addAttribute(eq("signinRequest"), any(SigninRequest.class));
+        verify(model, times(0)).addAttribute(eq("error"), any());
+    }
+
+    @Test
+    void loginPage_WithErrorParam_ShowsError() {
+        String result = oauthController.loginPage("true", null, model);
+
+        assertEquals("login", result);
+        verify(model, times(1)).addAttribute("error", true);
+        verify(model, times(1)).addAttribute("errorMessage", "Authentication failed");
+        verify(model, times(1)).addAttribute(eq("signinRequest"), any(SigninRequest.class));
+    }
+
+    @Test
+    void login_ValidCredentials_RedirectsToOauth2() {
+        SigninRequest signinRequest = new SigninRequest();
+        signinRequest.setLogin("testuser");
+        signinRequest.setPassword("password123");
+
+        JwtResponse jwtResponse = new JwtResponse();
+        jwtResponse.setToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+
+        when(authService.signin(signinRequest)).thenReturn(jwtResponse);
+
+        String result = oauthController.login(signinRequest, model);
+
+        assertEquals("redirect:/oauth2/redirect?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", result);
+        verify(authService, times(1)).signin(signinRequest);
+    }
+
+    @Test
+    void login_InvalidCredentials_ShowsError() {
+        SigninRequest signinRequest = new SigninRequest();
+        signinRequest.setLogin("testuser");
+        signinRequest.setPassword("password");
+
+        when(authService.signin(signinRequest))
+                .thenThrow(new RuntimeException("Authentication failed"));
+
+        String result = oauthController.login(signinRequest, model);
+
+        assertEquals("login", result);
+        verify(model, times(1)).addAttribute("error", true);
+        verify(model, times(1)).addAttribute("errorMessage", "Invalid credentials");
+        verify(model, times(1)).addAttribute("signinRequest", signinRequest);
+        verify(authService, times(1)).signin(signinRequest);
+    }
+
+    @Test
+    void oauth2Redirect_ValidToken_Success() {
+        String testToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+
+        String result = oauthController.oauth2Redirect(testToken, model);
+
+        assertEquals("oauth2-redirect", result);
+        verify(model, times(1)).addAttribute("accessToken", testToken);
+    }
+
+}

--- a/src/test/java/io/github/authmicroservice/controller/UserRoleControllerTest.java
+++ b/src/test/java/io/github/authmicroservice/controller/UserRoleControllerTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class UserRoleTest {
+public class UserRoleControllerTest {
 
     @MockitoBean
     private UserRoleService userRoleService;

--- a/src/test/java/io/github/authmicroservice/controller/UserRoleControllerTest.java
+++ b/src/test/java/io/github/authmicroservice/controller/UserRoleControllerTest.java
@@ -1,13 +1,16 @@
 package io.github.authmicroservice.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.authmicroservice.config.BaseTestSecurityConfig;
 import io.github.authmicroservice.model.dto.UserRolesRequest;
 import io.github.authmicroservice.model.entity.Role;
+import io.github.authmicroservice.security.config.SecurityConfig;
 import io.github.authmicroservice.service.UserRoleService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -24,7 +27,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
+@WebMvcTest(UserRolesController.class)
+@Import({SecurityConfig.class, BaseTestSecurityConfig.class})
 @AutoConfigureMockMvc
 public class UserRoleControllerTest {
 
@@ -76,7 +80,6 @@ public class UserRoleControllerTest {
 
     @Test
     void saveUserRoles_WithoutAuthentication_Unauthorized() throws Exception {
-
         UserRolesRequest request = new UserRolesRequest();
         request.setLogin("testuser");
         request.setRoles(Arrays.asList(Role.RoleType.USER));
@@ -84,7 +87,7 @@ public class UserRoleControllerTest {
         mockMvc.perform(put("/api/v1/user-roles/save")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isFound());
 
         verify(userRoleService, times(0)).saveUserRoles(any(UserRolesRequest.class));
     }
@@ -126,7 +129,7 @@ public class UserRoleControllerTest {
         String login = "testuser";
 
         mockMvc.perform(get("/api/v1/user-roles/{login}", login))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isFound());
 
         verify(userRoleService, times(0)).getUserRoles(eq(login));
     }

--- a/src/test/java/io/github/authmicroservice/integrationTest/OauthIntegrationTest.java
+++ b/src/test/java/io/github/authmicroservice/integrationTest/OauthIntegrationTest.java
@@ -1,0 +1,271 @@
+package io.github.authmicroservice.integrationTest;
+
+import io.github.authmicroservice.model.dto.GitHubLoginInfo;
+import io.github.authmicroservice.model.dto.GoogleLoginInfo;
+import io.github.authmicroservice.model.dto.JwtResponse;
+import io.github.authmicroservice.model.entity.Role;
+import io.github.authmicroservice.model.entity.User;
+import io.github.authmicroservice.model.entity.UserRole;
+import io.github.authmicroservice.model.enums.Provider;
+import io.github.authmicroservice.repository.RoleRepository;
+import io.github.authmicroservice.repository.UserRepository;
+import io.github.authmicroservice.repository.UserRoleRepository;
+import io.github.authmicroservice.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+public class OauthIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("auth_test")
+            .withUsername("auth")
+            .withPassword("1234");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private UserRoleRepository userRoleRepository;
+
+    private Role userRole;
+
+    @BeforeEach
+    void setUp() {
+
+        userRole = roleRepository.findById(Role.RoleType.USER)
+                .orElseGet(() -> roleRepository.save(Role.builder()
+                        .id(Role.RoleType.USER)
+                        .name("USER")
+                        .build()));
+    }
+
+    @Test
+    void googleOauthLoginProcess_NewUser_Success() {
+        GoogleLoginInfo googleInfo = GoogleLoginInfo.builder()
+                .id("google12345")
+                .email("test@gmail.com")
+                .name("Test User")
+                .picture("https://avatar.url")
+                .build();
+
+        JwtResponse response = authService.googleOauthLoginProcess(googleInfo);
+
+        assertNotNull(response);
+        assertNotNull(response.getToken());
+        assertEquals("test", response.getLogin());
+        assertEquals(List.of("ROLE_USER"), response.getRoles());
+
+        Optional<User> savedUser = userRepository.findByEmailWithRoles(googleInfo.getEmail());
+        assertTrue(savedUser.isPresent());
+
+        User user = savedUser.get();
+        assertEquals("test", user.getLogin());
+        assertEquals("test@gmail.com", user.getEmail());
+        assertEquals("Test User", user.getFullName());
+        assertEquals("https://avatar.url", user.getProfilePictureUrl());
+        assertEquals("google12345", user.getGoogleId());
+        assertEquals(Provider.GOOGLE, user.getProvider());
+        assertTrue(user.isActive());
+        assertEquals(1, user.getRoles().size());
+        assertEquals(Role.RoleType.USER, user.getRoles().get(0).getRole().getId());
+
+    }
+
+    @Test
+    void googleOauthLoginProcess_ExistingGoogleUser_UpdatesAndReturnsToken() {
+
+        User existingUser = User.builder()
+                .login("oldlogin")
+                .email("test@gmail.com")
+                .provider(Provider.GOOGLE)
+                .googleId("google123")
+                .fullName("Old Name")
+                .profilePictureUrl("https://old.avatar.url")
+                .active(true)
+                .build();
+
+        existingUser = userRepository.save(existingUser);
+
+        UserRole userRoleEntity = UserRole.builder()
+                .user(existingUser)
+                .role(userRole)
+                .build();
+
+        existingUser.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+        userRepository.save(existingUser);
+
+        GoogleLoginInfo googleInfo = GoogleLoginInfo.builder()
+                .id("google123")
+                .email("test@gmail.com")
+                .name("Updated Name")
+                .picture("https://new.avatar.url")
+                .build();
+
+        JwtResponse response = authService.googleOauthLoginProcess(googleInfo);
+
+        assertNotNull(response);
+        assertNotNull(response.getToken());
+        assertEquals("oldlogin", response.getLogin());
+        assertEquals(List.of("ROLE_USER"), response.getRoles());
+
+        Optional<User> updatedUser = userRepository.findByEmailWithRoles(googleInfo.getEmail());
+        assertTrue(updatedUser.isPresent());
+
+        User user = updatedUser.get();
+        assertEquals("oldlogin", user.getLogin());
+        assertEquals("Updated Name", user.getFullName());
+        assertEquals("https://new.avatar.url", user.getProfilePictureUrl());
+        assertEquals("google123", user.getGoogleId());
+    }
+
+
+    @Test
+    void githubOauthLoginProcess_NewUser_Success() {
+        GitHubLoginInfo githubInfo = GitHubLoginInfo.builder()
+                .id("github123")
+                .login("testuser")
+                .email("test@example.com")
+                .name("Test User")
+                .avatarUrl("https://github.avatar.url")
+                .build();
+
+        JwtResponse response = authService.githubOauthLoginProcess(githubInfo);
+
+        assertNotNull(response);
+        assertNotNull(response.getToken());
+        assertEquals("testuser", response.getLogin());
+        assertEquals(List.of("ROLE_USER"), response.getRoles());
+
+        Optional<User> savedUser = userRepository.findByGitHubIdWithRoles(githubInfo.getId());
+        assertTrue(savedUser.isPresent());
+
+        User user = savedUser.get();
+        assertEquals("testuser", user.getLogin());
+        assertEquals("test@example.com", user.getEmail());
+        assertEquals("Test User", user.getFullName());
+        assertEquals("https://github.avatar.url", user.getProfilePictureUrl());
+        assertEquals("github123", user.getGithubId());
+        assertEquals(Provider.GITHUB, user.getProvider());
+        assertTrue(user.isActive());
+        assertEquals(1, user.getRoles().size());
+        assertEquals(Role.RoleType.USER, user.getRoles().get(0).getRole().getId());
+    }
+
+    @Test
+    void githubOauthLoginProcess_ExistingGithubUser_UpdatesAndReturnsToken() {
+
+        User existingUser = User.builder()
+                .login("oldlogin")
+                .email("old@example.com")
+                .provider(Provider.GITHUB)
+                .githubId("github123")
+                .fullName("Old Name")
+                .profilePictureUrl("https://old.github.avatar.url")
+                .active(true)
+                .build();
+
+        existingUser = userRepository.save(existingUser);
+
+        UserRole userRoleEntity = UserRole.builder()
+                .user(existingUser)
+                .role(userRole)
+                .build();
+
+        existingUser.setRoles(new ArrayList<>(List.of(userRoleEntity)));
+        userRepository.save(existingUser);
+
+        GitHubLoginInfo githubInfo = GitHubLoginInfo.builder()
+                .id("github123")
+                .login("newlogin")
+                .email("new@example.com")
+                .name("Updated Name")
+                .avatarUrl("https://new.github.avatar.url")
+                .build();
+
+        JwtResponse response = authService.githubOauthLoginProcess(githubInfo);
+
+        assertNotNull(response);
+        assertNotNull(response.getToken());
+        assertEquals("oldlogin", response.getLogin());
+        assertEquals(List.of("ROLE_USER"), response.getRoles());
+
+        Optional<User> updatedUser = userRepository.findByGitHubIdWithRoles(githubInfo.getId());
+        assertTrue(updatedUser.isPresent());
+
+        User user = updatedUser.get();
+        assertEquals("oldlogin", user.getLogin());
+        assertEquals("Updated Name", user.getFullName());
+        assertEquals("https://new.github.avatar.url", user.getProfilePictureUrl());
+        assertEquals("github123", user.getGithubId());
+    }
+
+
+    @Test
+    void googleOauthLoginProcess_UserRoleNotFound_ThrowsException() {
+        roleRepository.deleteById(Role.RoleType.USER);
+
+        GoogleLoginInfo googleInfo = GoogleLoginInfo.builder()
+                .id("google123")
+                .email("test@gmail.com")
+                .name("Test User")
+                .picture("https://avatar.url")
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> authService.googleOauthLoginProcess(googleInfo));
+
+        assertTrue(exception.getMessage().contains("USER role not found"));
+    }
+
+    @Test
+    void githubOauthLoginProcess_UserRoleNotFound_ThrowsException() {
+        roleRepository.deleteById(Role.RoleType.USER);
+
+        GitHubLoginInfo githubInfo = GitHubLoginInfo.builder()
+                .id("github123")
+                .login("testuser")
+                .email("test@example.com")
+                .name("Test User")
+                .avatarUrl("https://github.avatar.url")
+                .build();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> authService.githubOauthLoginProcess(githubInfo));
+
+        assertTrue(exception.getMessage().contains("USER role not found"));
+    }
+}


### PR DESCRIPTION
## Что реализовано?
1) Логика аутентификации через Google и GitHub
2) Покрытие тестами
3) Обновленная дока

### Также вопросы по заданию:
1) Допускается ли использование `@Lazy` при возникновении Circular dependency, когда объекты зависят друг от друга и не могут создаться
```
public OAuth2AuthenticationSuccessHandler(@Lazy AuthService authService, GitHubApiService gitHubApiService) {
        this.authService = authService;
        this.gitHubApiService = gitHubApiService;
    }
```
2) Возникла такая проблема, что GitHub не всегда отдает почту пользователя (она не подтверждена или она скрыта от всех 🤷‍♂️ ). Пришлось написать отдельный сервис для запроса к API, но даже так не всегда ее получается получить. Но в БД у меня стоит ограничение NotNull на email. Можно ли решить данный вопрос без создания новой таблицы для oAuth пользователей?